### PR TITLE
Remove unnecessary instructions and add new tests

### DIFF
--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -513,6 +513,18 @@ fi
 
 CONFIG_FILE="config.json"
 
+if [ -z ${WHITELIST+x} ]; then
+    WHITELIST_SETTINGS="null"
+else
+    echo "[$(date "+%T")] Using whitelist: $WHITELIST"
+
+    # The following is what should be a correct whitelist config but Sugar currently has a bug not recognizing the proper `burnEveryTime` formatting.
+    # WHITELIST_SETTINGS="{\"mode\":{\"burnEveryTime\":true },\"mint\":\"$WHITELIST\",\"presale\":true,\"discountPrice\":null}"
+
+    # Until the bug is fixed, the following setting works for Sugar but doesn't follow the format documented in the Metaplex official docs
+    WHITELIST_SETTINGS="{\"mode\":\"burnEveryTime\",\"mint\":\"$WHITELIST\",\"presale\":true,\"discountPrice\":null}"
+fi
+
 if [ "$HIDDEN" = "Y" ]; then
     HIDDEN_SETTINGS="{\"name\":\"TEST Hidden Collection \",\"uri\":\"$METADATA_URL\",\"hash\":\"44kiGWWsSgdqPMvmqYgTS78Mx2BKCWzd\"}"
 else
@@ -544,7 +556,7 @@ cat >$CONFIG_FILE <<-EOM
     "splToken": $(quote_unless_null $SPL_TOKEN),
     "goLiveDate": "$(date "+%Y-%m-%dT%T%z" | sed "s@^.\{22\}@&:@")",
     "endSettings": null,
-    "whitelistMintSettings": null,
+    "whitelistMintSettings": $WHITELIST_SETTINGS,
     "hiddenSettings": $HIDDEN_SETTINGS,
     "uploadMethod": "${STORAGE}",
     "ipfsInfuraProjectId": "${INFURA_ID}",

--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -510,16 +510,21 @@ else
     HIDDEN_SETTINGS="null"
 fi
 
+PRICE=0.1
+SOL_TREASURY_ACCOUNT=$(solana address)
+SPL_TOKEN_ACCOUNT=null
+SPL_TOKEN=null
+
 cat >$CONFIG_FILE <<-EOM
 {
-    "price": 0.1,
+    "price": $PRICE,
     "number": $ITEMS,
     "symbol": "TEST",
     "sellerFeeBasisPoints": 500,
     "gatekeeper": null,
-    "solTreasuryAccount": "$(solana address)",
-    "splTokenAccount": null,
-    "splToken": null,
+    "solTreasuryAccount": "${SOL_TREASURY_ACCOUNT}",
+    "splTokenAccount": ${SPL_TOKEN_ACCOUNT},
+    "splToken": ${SPL_TOKEN},
     "goLiveDate": "$(date "+%Y-%m-%dT%T%z" | sed "s@^.\{22\}@&:@")",
     "endSettings": null,
     "whitelistMintSettings": null,

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -377,19 +377,20 @@ pub fn mint(
 
     let sig = builder.send()?;
 
-    // Cleanup instructions, such as revoke token burn authority, require a separate transaction.
-    let mut builder = program.request();
+    info!("Minted! TxId: {}", sig);
 
     if !cleanup_instructions.is_empty() {
+        // Cleanup instructions, such as revoke token burn authority, require a separate transaction.
+        let mut builder = program.request();
+
         for instruction in cleanup_instructions {
             builder = builder.instruction(instruction);
         }
+
+        let sig2 = builder.send()?;
+
+        info!("Cleanup TxId: {}", sig2);
     }
-
-    let sig2 = builder.send()?;
-
-    info!("Minted! TxId: {}", sig);
-    info!("Cleanup TxId: {}", sig2);
 
     Ok(sig)
 }


### PR DESCRIPTION
This PR's focus is about removing unneeded approve/revoke instructions when burning a whitelist token and when paying mint with a custom token.

In order to do that, it also adds some basic automated tests for those two cases. That being said, I found Sugar does not expect whitelist settings format exactly as documented in Candy Machine v2's docs. Fixing that bug is not the focus of this PR so I only documented the issue in the tests and added a test using the config format Sugar does currently support.

The last commit deletes a bunch of code that is not needed anymore but might be needed once setting collection during mint is supported in Sugar.

I highly recommend reviewing the PR commit by commit.